### PR TITLE
Fix Dashboard Statistics Inconsistency and Status Mismatch

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -19,9 +19,9 @@ class AdminController extends Controller
         // Simple stats for dashboard
         $stats = [
             'total_antrian' => Queue::whereDate('created_at', Carbon::today())->count(),
-            'selesai' => Queue::whereDate('created_at', Carbon::today())->where('status', 'selesai')->count(),
-            'menunggu' => Queue::whereDate('created_at', Carbon::today())->where('status', 'menunggu')->count(),
-            'batal' => Queue::whereDate('created_at', Carbon::today())->where('status', 'batal')->count(),
+            'selesai' => Queue::whereDate('created_at', Carbon::today())->where('status', Queue::STATUS_DONE)->count(),
+            'menunggu' => Queue::whereDate('created_at', Carbon::today())->where('status', Queue::STATUS_WAITING)->count(),
+            'batal' => Queue::whereDate('created_at', Carbon::today())->where('status', Queue::STATUS_SKIPPED)->count(),
         ];
         
         return view('admin.rekap', compact('stats'));
@@ -94,6 +94,7 @@ class AdminController extends Controller
             ->leftJoin('users', 'queues.user_id', '=', 'users.id')
             ->leftJoin('services', 'queues.service_id', '=', 'services.id')
             ->leftJoin('schedules', 'queues.schedule_id', '=', 'schedules.id')
+            ->whereDate('queues.created_at', Carbon::today())
             ->select([
                 'queues.id',
                 'users.name as nama_pasien',
@@ -117,10 +118,10 @@ class AdminController extends Controller
             })
             ->editColumn('status', function($row) {
                 $color = match($row->status) {
-                    'menunggu' => 'yellow',
-                    'dipanggil' => 'blue',
-                    'selesai' => 'green',
-                    'batal' => 'red',
+                    Queue::STATUS_WAITING => 'yellow',
+                    Queue::STATUS_CALLED, Queue::STATUS_PROCESSING => 'blue',
+                    Queue::STATUS_DONE => 'green',
+                    Queue::STATUS_SKIPPED => 'red',
                     default => 'gray'
                 };
                 return '<span class="px-2 py-1 text-xs font-semibold rounded-full bg-'.$color.'-100 text-'.$color.'-800">'.ucfirst($row->status).'</span>';

--- a/app/Models/Queue.php
+++ b/app/Models/Queue.php
@@ -13,6 +13,15 @@ class Queue extends Model
     use HasFactory;
 
     /**
+     * Queue Statuses
+     */
+    public const STATUS_WAITING = 'waiting';
+    public const STATUS_CALLED = 'called';
+    public const STATUS_PROCESSING = 'processing';
+    public const STATUS_DONE = 'done';
+    public const STATUS_SKIPPED = 'skipped';
+
+    /**
      * Get the user that owns the queue.
      */
     public function user(): \Illuminate\Database\Eloquent\Relations\BelongsTo


### PR DESCRIPTION
This PR resolves the mismatch between dashboard summary cards and the queue table.

Key changes:
- Standardized queue statuses using constants in the Queue model.
- Updated AdminController statistics logic to use correct enum values.
- Synced the dashboard table to only show today's data to match the stats cards.

Closes #23